### PR TITLE
feat: EventRouter Updates

### DIFF
--- a/src/event-router/dispatch-route-provider.spec.ts
+++ b/src/event-router/dispatch-route-provider.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { fake } from 'sinon';
+
+import { DispatchRouteProvider } from './dispatch-route-provider.js';
+
+describe('DispatchRouteProvider', function () {
+  it('should throw an error when no routes are provided', function () {
+    expect(() => new DispatchRouteProvider({ routes: [] })).to.throw(
+      'DispatchRouteProvider requires at least one route',
+    );
+  });
+
+  it('should return the provided routes', async function () {
+    const route1 = fake();
+    const route2 = fake();
+    const routeProvider = new DispatchRouteProvider({
+      routes: [route1, route2],
+    });
+
+    const routes = await routeProvider.get();
+
+    expect(routes).to.deep.equal([route1, route2]);
+  });
+});

--- a/src/event-router/dispatch-route-provider.ts
+++ b/src/event-router/dispatch-route-provider.ts
@@ -1,0 +1,39 @@
+import {
+  AbstractEventService,
+  EventServiceOptions,
+} from '../abstract-event-service.js';
+import {
+  Event,
+  EventEndpointComponent,
+  EventHandlerFn,
+} from '../types/index.js';
+import { RouteProvider } from './types/route-provider.js';
+import { getEventHandlerComponent } from '../util/get-event-handler-component.js';
+
+export type DispatchRouteProviderOptions<T extends Event = Event> =
+  EventServiceOptions & {
+    routes: EventEndpointComponent<T>[];
+  };
+
+export class DispatchRouteProvider<T extends Event = Event>
+  extends AbstractEventService
+  implements RouteProvider<T>
+{
+  #routes: EventHandlerFn<T>[] = [];
+
+  constructor(opts: DispatchRouteProviderOptions<T>) {
+    super(opts);
+
+    if (!opts.routes || [opts.routes].flat().length === 0) {
+      throw new Error('DispatchRouteProvider requires at least one route');
+    }
+
+    this.#routes = [opts.routes]
+      .flat()
+      .map(route => getEventHandlerComponent(route));
+  }
+
+  async get(): Promise<EventHandlerFn<T>[]> {
+    return this.#routes;
+  }
+}

--- a/src/event-router/event-router.ts
+++ b/src/event-router/event-router.ts
@@ -5,10 +5,17 @@ import {
   EventServiceOptions,
 } from '../abstract-event-service.js';
 import { Event, EventChannel } from '../types/index.js';
-import { RouteProvider, RouteProviderFn } from './types/index.js';
+import {
+  ExecutionStrategyComponent,
+  ExecutionStrategyFn,
+  RouteProvider,
+  RouteProviderFn,
+} from './types/index.js';
+import { ParallelStrategy } from './execution-strategies/index.js';
 
 type EventRouterOptions<T extends Event = Event> = EventServiceOptions & {
   routeProvider: RouteProvider<T> | RouteProviderFn<T>;
+  executionStrategy?: ExecutionStrategyComponent<T>;
 };
 
 /**
@@ -20,16 +27,23 @@ export class EventRouter<T extends Event = Event>
   implements EventChannel<T>
 {
   #routeProvider: RouteProviderFn<T>;
+  #executionStrategy: ExecutionStrategyFn<T>;
 
   constructor(options: EventRouterOptions<T>) {
     super(options);
     this.#routeProvider = getComponent(options.routeProvider, 'get');
+
+    this.#executionStrategy = getComponent(
+      options.executionStrategy,
+      'execute',
+      new ParallelStrategy<T>(),
+    );
   }
 
   async send(event: T): Promise<void> {
     this.emit('event:received', event);
     const routes = await this.#routeProvider(event);
-    await Promise.all([routes].flat().map(route => route(event)));
+    await this.#executionStrategy(event, [routes].flat());
     this.emit('event:delivered', event);
   }
 }

--- a/src/event-router/execution-strategies/index.ts
+++ b/src/event-router/execution-strategies/index.ts
@@ -1,0 +1,3 @@
+export * from './paralellel-strategy.js';
+export * from './round-robin-strategy.js';
+export * from './serial-strategy.js';

--- a/src/event-router/execution-strategies/paralellel-strategy.spec.ts
+++ b/src/event-router/execution-strategies/paralellel-strategy.spec.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { fake } from 'sinon';
+
+import { EventBuilder } from '../../event-builder.js';
+import { ParallelStrategy } from './paralellel-strategy.js';
+
+describe('ParallelStrategy', function () {
+  it('should execute all handlers in parallel', async function () {
+    const event = await new EventBuilder().create();
+    const handler1 = fake();
+    const handler2 = fake();
+    const strategy = new ParallelStrategy();
+
+    await strategy.execute(event, [handler1, handler2]);
+
+    expect(handler1.calledOnceWith(event)).to.be.true;
+    expect(handler2.calledOnceWith(event)).to.be.true;
+  });
+});

--- a/src/event-router/execution-strategies/paralellel-strategy.ts
+++ b/src/event-router/execution-strategies/paralellel-strategy.ts
@@ -1,0 +1,7 @@
+import { Event, EventHandlerFn } from '../../types/index.js';
+
+export class ParallelStrategy<T extends Event = Event> {
+  async execute(event: T, handlers: EventHandlerFn<T>[]): Promise<void> {
+    await Promise.all(handlers.map(handler => handler(event)));
+  }
+}

--- a/src/event-router/execution-strategies/round-robin-strategy.spec.ts
+++ b/src/event-router/execution-strategies/round-robin-strategy.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import { fake } from 'sinon';
+
+import { EventBuilder } from '../../event-builder.js';
+import { RoundRobinStrategy } from './round-robin-strategy.js';
+
+describe('RoundRobinStrategy', function () {
+  it('should execute all handlers in round-robin', async function () {
+    const event = await new EventBuilder().create();
+    const handler1 = fake();
+    const handler2 = fake();
+    const handler3 = fake();
+    const strategy = new RoundRobinStrategy();
+    await strategy.execute(event, [handler1, handler2, handler3]);
+
+    expect(handler1.calledOnceWith(event)).to.be.true;
+    expect(handler2.calledOnceWith(event)).to.be.false;
+    expect(handler3.calledOnceWith(event)).to.be.false;
+
+    await strategy.execute(event, [handler1, handler2, handler3]);
+    expect(handler1.calledOnceWith(event)).to.be.true;
+    expect(handler2.calledOnceWith(event)).to.be.true;
+    expect(handler3.calledOnceWith(event)).to.be.false;
+
+    await strategy.execute(event, [handler1, handler2, handler3]);
+    expect(handler1.calledOnceWith(event)).to.be.true;
+    expect(handler2.calledOnceWith(event)).to.be.true;
+    expect(handler3.calledOnceWith(event)).to.be.true;
+
+    await strategy.execute(event, [handler1, handler2, handler3]);
+    expect(handler1.callCount).to.equal(2);
+    expect(handler2.calledOnceWith(event)).to.be.true;
+    expect(handler3.calledOnceWith(event)).to.be.true;
+  });
+});

--- a/src/event-router/execution-strategies/round-robin-strategy.ts
+++ b/src/event-router/execution-strategies/round-robin-strategy.ts
@@ -1,0 +1,10 @@
+import { Event, EventHandlerFn } from '../../types/index.js';
+
+export class RoundRobinStrategy<T extends Event = Event> {
+  #lastIndex = -1;
+
+  async execute(event: T, handlers: EventHandlerFn<T>[]): Promise<void> {
+    this.#lastIndex = (this.#lastIndex + 1) % handlers.length;
+    await handlers[this.#lastIndex](event);
+  }
+}

--- a/src/event-router/execution-strategies/serial-strategy.spec.ts
+++ b/src/event-router/execution-strategies/serial-strategy.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+
+import { EventBuilder } from '../../event-builder.js';
+import { SerialStrategy } from './serial-strategy.js';
+
+describe('SerialStrategy', function () {
+  it('should execute all handlers in serial', async function () {
+    const event = await EventBuilder.create();
+    let value = 0;
+    const handler1 = async () => {
+      value = 1;
+    };
+    const handler2 = async () => {
+      expect(value).to.equal(1);
+      value = 2;
+    };
+    const handler3 = async () => {
+      expect(value).to.equal(2);
+      value = 3;
+    };
+
+    const strategy = new SerialStrategy();
+    await strategy.execute(event, [handler1, handler2, handler3]);
+  });
+});

--- a/src/event-router/execution-strategies/serial-strategy.ts
+++ b/src/event-router/execution-strategies/serial-strategy.ts
@@ -1,0 +1,9 @@
+import { Event, EventHandlerFn } from '../../types/index.js';
+
+export class SerialStrategy<T extends Event = Event> {
+  async execute(event: T, handlers: EventHandlerFn<T>[]): Promise<void> {
+    for (const handler of handlers) {
+      await handler(event);
+    }
+  }
+}

--- a/src/event-router/get-route-component.ts
+++ b/src/event-router/get-route-component.ts
@@ -1,9 +1,0 @@
-import { getComponent } from '@sektek/utility-belt';
-
-import { Route, RouteFn } from './types/index.js';
-import { Event } from '../types/index.js';
-
-export const getRouteComponent = <T extends Event = Event>(
-  route: Route<T> | null | undefined,
-  fallback?: Route<T>,
-): RouteFn<T> => getComponent(route, ['handle', 'send', 'process'], fallback);

--- a/src/event-router/route-store.ts
+++ b/src/event-router/route-store.ts
@@ -13,7 +13,7 @@ import {
 } from './types/index.js';
 import { Event } from '../types/index.js';
 import { NullHandler } from '../null-handler.js';
-import { getRouteComponent } from './get-route-component.js';
+import { getEventHandlerComponent } from '../util/get-event-handler-component.js';
 
 type RouteRecord<T extends Event = Event> = Record<string, Route<T>>;
 
@@ -38,9 +38,9 @@ export class RouteStore<T extends Event = Event>
   constructor(opts: RouteStoreOptions<T>) {
     super(opts);
     this.#routeDecider = getComponent(opts.routeDecider, 'get');
-    this.#defaultRoute = getRouteComponent(
+    this.#defaultRoute = getEventHandlerComponent(
       opts.defaultRoute,
-      new NullHandler(),
+      new NullHandler<T>(),
     );
     if (opts.routes) {
       Object.entries(opts.routes).forEach(([name, route]) =>
@@ -50,7 +50,7 @@ export class RouteStore<T extends Event = Event>
   }
 
   add(name: string, route: Route<T>): void {
-    this.routes.set(name, getRouteComponent(route));
+    this.routes.set(name, getEventHandlerComponent(route));
   }
 
   remove(names: string | string[]): void {

--- a/src/event-router/types/execution-strategy.ts
+++ b/src/event-router/types/execution-strategy.ts
@@ -1,0 +1,18 @@
+import { Component } from '@sektek/utility-belt';
+
+import { Event } from '../../types/event.js';
+import { EventHandlerFn } from '../../types/event-handler.js';
+
+export type ExecutionStrategyFn<T extends Event = Event> = (
+  event: T,
+  handlers: EventHandlerFn<T>[],
+) => PromiseLike<void>;
+
+export interface ExecutionStrategy<T extends Event = Event> {
+  execute: ExecutionStrategyFn<T>;
+}
+
+export type ExecutionStrategyComponent<T extends Event = Event> = Component<
+  ExecutionStrategy<T>,
+  'execute'
+>;

--- a/src/event-router/types/index.ts
+++ b/src/event-router/types/index.ts
@@ -1,2 +1,3 @@
+export * from './execution-strategy.js';
 export * from './route-decider.js';
 export * from './route-provider.js';


### PR DESCRIPTION
- Adds ExecutionStrategy with three implementations
  - Parallel Execution
  - Serial Execution
  - Round Robin Execution (Intended for use with new Dispatch Route Provider)
- Adds DispatchRouteProvider to allow EventRouter to serve as a Dispatcher. This RouteProvider returns a static array of routes opposed to using a RouteDecider.