### PR TITLE
fix: CompositeHeadersProvider requires name property

### DIFF
--- a/src/http/composite-headers-provider.spec.ts
+++ b/src/http/composite-headers-provider.spec.ts
@@ -7,10 +7,9 @@ describe('CompositeHeadersProvider', function () {
   it('should return the headers from both providers', async function () {
     const provider1 = () => ({ 'Content-Type': 'application/json' });
     const provider2 = () => ({ Authorization: 'Bearer token' });
-    const compositeProvider = new CompositeHeadersProvider(
-      provider1,
-      provider2,
-    );
+    const compositeProvider = new CompositeHeadersProvider({
+      providers: [provider1, provider2],
+    });
 
     const event = await EventBuilder.create();
     const headers = await compositeProvider.get(event);

--- a/src/http/composite-headers-provider.ts
+++ b/src/http/composite-headers-provider.ts
@@ -1,19 +1,34 @@
 import { getComponent } from '@sektek/utility-belt';
 
 import {
+  AbstractEventService,
+  EventServiceOptions,
+} from '../abstract-event-service.js';
+import { Event } from '../types/index.js';
+
+import {
   HeadersProvider,
   HeadersProviderComponent,
   HeadersProviderFn,
 } from './types/index.js';
-import { Event } from '../types/index.js';
+
+export type CompositeHeadersProviderOptions<T extends Event = Event> =
+  EventServiceOptions & {
+    providers: HeadersProviderComponent<T> | HeadersProviderComponent<T>[];
+  };
 
 export class CompositeHeadersProvider<T extends Event = Event>
+  extends AbstractEventService
   implements HeadersProvider<T>
 {
   #providers: HeadersProviderFn<T>[];
 
-  constructor(...providers: HeadersProviderComponent<T>[]) {
-    this.#providers = providers.map(provider => getComponent(provider, 'get'));
+  constructor(opts: CompositeHeadersProviderOptions<T>) {
+    super(opts);
+
+    this.#providers = [opts.providers]
+      .flat()
+      .map(provider => getComponent(provider, 'get'));
   }
 
   async get(event: T): Promise<Headers> {

--- a/src/http/simple-http-event-service.ts
+++ b/src/http/simple-http-event-service.ts
@@ -62,10 +62,12 @@ export class SimpleHttpEventService<T extends Event = Event>
     const contentType = opts.contentType ?? 'application/json';
     if (opts.headersProvider && opts.contentType) {
       this.#headersProvider = getComponent(
-        new CompositeHeadersProvider<T>(
-          opts.headersProvider,
-          contentTypeHeadersProvider(contentType),
-        ) as HeadersProviderComponent<T>,
+        new CompositeHeadersProvider<T>({
+          providers: [
+            opts.headersProvider,
+            contentTypeHeadersProvider(contentType),
+          ],
+        }) as HeadersProviderComponent<T>,
         'get',
       );
     } else {


### PR DESCRIPTION
Updated CompositeHeadersProvider to be a child of AbstractEventService