### PR TITLE
fix: provide default opts for AbstractEventService constructor

### DIFF
--- a/src/abstract-event-service.ts
+++ b/src/abstract-event-service.ts
@@ -24,7 +24,7 @@ export abstract class AbstractEventService
 {
   #name: string;
 
-  constructor(opts: EventServiceOptions) {
+  constructor(opts: EventServiceOptions = {}) {
     super();
     this.#name = opts.name ?? generateName(this.constructor.name);
   }


### PR DESCRIPTION
Minor fix to allow AbstractEventService's constructor to be called without arguments