### PR TITLE
feat: PromiseChannel timeouts and state

### DIFF
--- a/src/channels/processing-channel.ts
+++ b/src/channels/processing-channel.ts
@@ -1,4 +1,4 @@
-import { getComponent } from '@sektek/utility-belt';
+import { EventEmittingService, getComponent } from '@sektek/utility-belt';
 
 import {
   AbstractEventHandlingService,
@@ -6,7 +6,6 @@ import {
 } from '../abstract-event-handling-service.js';
 import {
   Event,
-  EventChannel,
   EventChannelEvents,
   EventProcessor,
   EventProcessorFn,
@@ -20,24 +19,12 @@ export type ProcessingChannelOptions<
   processor: EventProcessor<T, R> | EventProcessorFn<T, R>;
 };
 
-export interface ProcessingChannelEvents<
+export type ProcessingChannelEvents<
   T extends Event = Event,
   R extends Event = Event,
-> extends EventChannelEvents<T> {
+> = EventChannelEvents<T> & {
   'event:delivered': (event: R) => void;
-}
-
-interface ProcessingChannelEventEmitter<T extends Event, R extends Event>
-  extends EventChannel<T> {
-  on<E extends keyof ProcessingChannelEvents<T, R>>(
-    event: E,
-    listener: ProcessingChannelEvents<T, R>[E],
-  ): this;
-  emit<E extends keyof ProcessingChannelEvents<T, R>>(
-    event: E,
-    ...args: Parameters<ProcessingChannelEvents<T, R>[E]>
-  ): boolean;
-}
+};
 
 /**
  * A channel that performs processing on an event prior to send it to
@@ -48,7 +35,7 @@ interface ProcessingChannelEventEmitter<T extends Event, R extends Event>
  */
 export class ProcessingChannel<T extends Event = Event, R extends Event = T>
   extends AbstractEventHandlingService<R>
-  implements ProcessingChannelEventEmitter<T, R>
+  implements EventEmittingService<ProcessingChannelEvents<T, R>>
 {
   #processor: EventProcessorFn<T, R>;
 

--- a/src/channels/promise-channel.spec.ts
+++ b/src/channels/promise-channel.spec.ts
@@ -1,10 +1,22 @@
-import { expect } from 'chai';
+import { expect, use } from 'chai';
+import { fake, match } from 'sinon';
+import chaiAsPromised from 'chai-as-promised';
+import sinonChai from 'sinon-chai';
 
 import { Event } from '../types/index.js';
 import { EventBuilder } from '../event-builder.js';
 import { PromiseChannel } from './promise-channel.js';
 
+use(chaiAsPromised);
+use(sinonChai);
+
 describe('PromiseChannel', function () {
+  it('should initialize to a pending state', async function () {
+    const channel = new PromiseChannel<Event>();
+
+    expect(channel.state).to.equal('pending');
+  });
+
   it('should resolve the promise when sending an event', async function () {
     const channel = new PromiseChannel<Event>();
     const event = await new EventBuilder().create();
@@ -13,6 +25,14 @@ describe('PromiseChannel', function () {
 
     const result = await promise;
     expect(result).to.equal(event);
+  });
+
+  it('should have a state of fulfilled after sending an event', async function () {
+    const channel = new PromiseChannel<Event>();
+    const event = await new EventBuilder().create();
+    await channel.send(event);
+
+    expect(channel.state).to.equal('fulfilled');
   });
 
   it('should emit an event:received event when sending an event', async function () {
@@ -31,5 +51,42 @@ describe('PromiseChannel', function () {
       expect(value).to.equal(event);
     });
     await channel.send(event);
+  });
+
+  it('should emit an event:error event when sending an event after the promise has been resolved', async function () {
+    const listener = fake();
+    const channel = new PromiseChannel<Event>();
+    const event = await new EventBuilder().create();
+    await channel.send(event);
+    channel.on('event:error', listener);
+    expect(channel.send(event)).to.be.rejectedWith('Promise already resolved');
+
+    expect(
+      listener.calledOnceWith(
+        match
+          .instanceOf(Error)
+          .and(match.has('message', 'Promise already resolved')),
+      ),
+    ).to.be.true;
+  });
+
+  it('should emit an event:error event when the get times out', async function () {
+    const listener = fake();
+    const channel = new PromiseChannel<Event>({ timeout: 10 });
+    channel.on('event:error', listener);
+    await expect(channel.get()).to.be.rejectedWith('Promise timed out');
+
+    expect(
+      listener.calledOnceWith(
+        match.instanceOf(Error).and(match.has('message', 'Promise timed out')),
+      ),
+    ).to.be.true;
+  });
+
+  it('should have a rejected state when the promise is rejected', async function () {
+    const channel = new PromiseChannel<Event>({ timeout: 10 });
+    await expect(channel.get()).to.be.rejectedWith('Promise timed out');
+
+    expect(channel.state).to.equal('rejected');
   });
 });

--- a/src/channels/promise-channel.ts
+++ b/src/channels/promise-channel.ts
@@ -14,8 +14,10 @@ type PromiseChannelEvents<T extends Event = Event> = EventChannelEvents<T> & {
 };
 
 export type PromiseChannelOptions = EventServiceOptions & {
-  timeout: number;
+  timeout?: number;
 };
+
+const DEFAULT_TIMEOUT = 0;
 
 /**
  * An EventChannel class that resolves a promise when an event is sent to it.
@@ -33,9 +35,9 @@ export class PromiseChannel<T extends Event = Event>
   #resolve?: (value: T | PromiseLike<T>) => void;
   #reject?: (reason?: unknown) => void;
 
-  constructor(opts: PromiseChannelOptions = { timeout: 0 }) {
+  constructor(opts: PromiseChannelOptions = { timeout: DEFAULT_TIMEOUT }) {
     super(opts);
-    this.#timeout = opts.timeout;
+    this.#timeout = opts.timeout ?? DEFAULT_TIMEOUT;
     this.#promise = new Promise<T>((resolve, reject) => {
       this.#resolve = (value: T | PromiseLike<T>) => {
         this.#state = 'fulfilled';

--- a/src/types/event-channel.ts
+++ b/src/types/event-channel.ts
@@ -1,4 +1,4 @@
-import { Component } from '@sektek/utility-belt';
+import { Component, EventEmittingService } from '@sektek/utility-belt';
 import { Event } from './event.js';
 import { EventHandlerFn } from './event-handler.js';
 import { EventService } from './event-service.js';
@@ -12,11 +12,11 @@ import { EventService } from './event-service.js';
  */
 export type EventChannelFn<T extends Event> = EventHandlerFn<T, void>;
 
-export interface EventChannelEvents<T extends Event = Event> {
+export type EventChannelEvents<T extends Event = Event> = {
   'event:received': (event: T) => void;
   'event:delivered': (event: Event) => void;
   'event:error': (event: Event, err: Error) => void;
-}
+};
 
 /**
  * An EventChannel is an event handler that specifically should be used to
@@ -25,16 +25,10 @@ export interface EventChannelEvents<T extends Event = Event> {
  *
  * @typeParam T - The event type that the channel can send.
  */
-export interface EventChannel<T extends Event = Event> extends EventService {
+export interface EventChannel<T extends Event = Event>
+  extends EventService,
+    EventEmittingService<EventChannelEvents<T>> {
   send: EventChannelFn<T>;
-  on<E extends keyof EventChannelEvents<T>>(
-    event: E,
-    listener: EventChannelEvents<T>[E],
-  ): this;
-  emit<E extends keyof EventChannelEvents<T>>(
-    event: E,
-    ...args: Parameters<EventChannelEvents<T>[E]>
-  ): boolean;
 }
 
 export type EventChannelComponent<T extends Event = Event> = Component<


### PR DESCRIPTION
This adds a timeout feature to the PromiseChannel along with the ability to check the state of the channel.

Further moves EventChannel to use EventEmittingService interface.