### PR TITLE
Feat: Introduce RequestReplyProcessor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,5 @@ export * from './event-router/index.js';
 export * from './null-handler.js';
 export * from './util/index.js';
 export * from './null-handler.js';
+export * from './request-reply-processor/index.js';
 export * from './types/index.js';

--- a/src/request-reply-processor/index.ts
+++ b/src/request-reply-processor/index.ts
@@ -1,0 +1,1 @@
+export * from './request-reply-processor.js';

--- a/src/request-reply-processor/reply-route-provider.spec.ts
+++ b/src/request-reply-processor/reply-route-provider.spec.ts
@@ -1,0 +1,52 @@
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+
+import { EventBuilder } from '../event-builder.js';
+import { ReplyRouteProvider } from './reply-route-provider.js';
+
+use(chaiAsPromised);
+
+describe('ReplyRouteProvider', function () {
+  describe('create', function () {
+    it('should return a PromiseChannel function', async function () {
+      const provider = new ReplyRouteProvider();
+      const channel = provider.create('test');
+
+      expect(channel).to.be.a('object');
+      expect(channel.constructor.name).to.equal('PromiseChannel');
+    });
+  });
+
+  describe('get', function () {
+    it('should return the channel', async function () {
+      const event = await EventBuilder.create();
+      const reply = await new EventBuilder({
+        headers: { replyTo: [event.id] },
+      }).create();
+      const provider = new ReplyRouteProvider();
+      const channel = provider.create(event.id);
+
+      provider.get(reply)(reply);
+
+      const result = await channel.get();
+      expect(result).to.equal(reply);
+    });
+  });
+
+  describe('delete', function () {
+    it('should delete the channel', async function () {
+      const event = await EventBuilder.create();
+      const reply = await new EventBuilder({
+        headers: { replyTo: [event.id] },
+      }).create();
+      const provider = new ReplyRouteProvider();
+      provider.create(event.id);
+
+      provider.delete(event.id);
+
+      expect(() => provider.get(reply)).to.throw(
+        `No channel found for event with id: ${event.id}`,
+      );
+    });
+  });
+});

--- a/src/request-reply-processor/reply-route-provider.ts
+++ b/src/request-reply-processor/reply-route-provider.ts
@@ -1,0 +1,39 @@
+import { Event, EventHandlerFn } from '../types/index.js';
+import { AbstractEventService } from '../abstract-event-service.js';
+import { PromiseChannel } from '../channels/index.js';
+import { RouteProvider } from '../event-router/index.js';
+import { getEventHandlerComponent } from '../util/index.js';
+
+export class ReplyRouteProvider<T extends Event = Event>
+  extends AbstractEventService
+  implements RouteProvider<T>
+{
+  #channelMap = new Map<string, PromiseChannel<T>>();
+
+  get(event: T): EventHandlerFn<T> {
+    const replyTo = event.replyTo?.pop();
+    const channel = this.#channelMap.get(replyTo ?? '');
+    if (!channel) {
+      throw new Error(`No channel found for event with id: ${replyTo}`);
+    }
+
+    return getEventHandlerComponent(channel);
+  }
+
+  create(id: string): PromiseChannel<T> {
+    const channel = new PromiseChannel<T>();
+    this.#channelMap.set(id, channel);
+
+    channel.on('channel:stateChange', () => this.delete(id));
+
+    return channel;
+  }
+
+  delete(id: string): void {
+    if (id.length === 0) {
+      return;
+    }
+
+    this.#channelMap.delete(id);
+  }
+}

--- a/src/request-reply-processor/request-reply-processor.spec.ts
+++ b/src/request-reply-processor/request-reply-processor.spec.ts
@@ -1,0 +1,88 @@
+import { expect, use } from 'chai';
+import { fake, match } from 'sinon';
+import chaiAsPromised from 'chai-as-promised';
+
+import { EventBuilder } from '../event-builder.js';
+import { RequestReplyProcessor } from './request-reply-processor.js';
+
+use(chaiAsPromised);
+
+describe('RequestReplyProcessor', function () {
+  it('should return a promise', async function () {
+    const handler = fake();
+    const processorChannel = new RequestReplyProcessor({ handler });
+    const event = await new EventBuilder().create();
+
+    const promise = processorChannel.process(event);
+
+    expect(handler.calledOnceWith(match.has('id', event.id))).to.be.true;
+    expect(promise).to.be.instanceOf(Promise);
+  });
+
+  it('should resolve the promise when a matching reply is received', async function () {
+    const handler = fake();
+    const processorChannel = new RequestReplyProcessor({ handler });
+    const event = await new EventBuilder().create();
+
+    const promise = processorChannel.process(event);
+    const reply = await new EventBuilder().create();
+    reply.replyTo = [event.id];
+
+    processorChannel.channel(reply);
+
+    const result = await promise;
+    expect(result).to.equal(reply);
+  });
+
+  it('should throw an error when a non-matching reply is received', async function () {
+    const handler = fake();
+    const processorChannel = new RequestReplyProcessor({ handler });
+    const event = await new EventBuilder().create();
+
+    processorChannel.process(event);
+    const reply = await new EventBuilder().create();
+    reply.replyTo = ['non-matching-id'];
+
+    expect(processorChannel.channel(reply)).to.be.rejectedWith(
+      'No channel found for event with id: non-matching-id',
+    );
+  });
+
+  it('should emit an event:received event when processing an event', async function () {
+    const handler = fake();
+    const listener = fake();
+    const processorChannel = new RequestReplyProcessor({ handler });
+    const event = await new EventBuilder().create();
+
+    processorChannel.on('event:received', listener);
+
+    const promise = processorChannel.process(event);
+
+    const reply = await new EventBuilder().create();
+    reply.replyTo = [event.id];
+
+    await processorChannel.channel(reply);
+    await promise;
+
+    expect(listener.calledOnceWith(event)).to.be.true;
+  });
+
+  it('should emit an event:processed event when processing an event', async function () {
+    const handler = fake();
+    const listener = fake();
+    const processorChannel = new RequestReplyProcessor({ handler });
+    const event = await new EventBuilder().create();
+
+    processorChannel.on('event:processed', listener);
+
+    const promise = processorChannel.process(event);
+
+    const reply = await new EventBuilder().create();
+    reply.replyTo = [event.id];
+
+    await processorChannel.channel(reply);
+    await promise;
+
+    expect(listener.calledOnceWith(event, reply)).to.be.true;
+  });
+});

--- a/src/request-reply-processor/request-reply-processor.ts
+++ b/src/request-reply-processor/request-reply-processor.ts
@@ -1,0 +1,46 @@
+import {
+  AbstractEventHandlingService,
+  EventHandlingServiceOptions,
+} from '../abstract-event-handling-service.js';
+import { Event, EventHandlerFn, EventProcessor } from '../types/index.js';
+import { EventRouter } from '../event-router/event-router.js';
+import { ReplyRouteProvider } from './reply-route-provider.js';
+import { getEventHandlerComponent } from '../util/index.js';
+
+export class RequestReplyProcessor<T extends Event = Event, R extends Event = T>
+  extends AbstractEventHandlingService
+  implements EventProcessor<T, R>
+{
+  #replyRouteProvider: ReplyRouteProvider<R>;
+  #replyChannel: EventHandlerFn<R>;
+
+  constructor(opts: EventHandlingServiceOptions) {
+    super(opts);
+
+    this.#replyRouteProvider = new ReplyRouteProvider<R>();
+    const replyRouter = new EventRouter<R>({
+      routeProvider: this.#replyRouteProvider,
+    });
+    this.#replyChannel = getEventHandlerComponent(replyRouter);
+  }
+
+  async process(event: T): Promise<R> {
+    this.emit('event:received', event);
+
+    const channel = this.#replyRouteProvider.create(event.id);
+    channel.on('event:delivered', result =>
+      this.emit('event:processed', event, result),
+    );
+
+    event.replyTo ??= [];
+    event.replyTo.push(event.id);
+
+    await this.handler(event);
+
+    return channel.get();
+  }
+
+  get channel(): EventHandlerFn<R> {
+    return this.#replyChannel;
+  }
+}

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -3,6 +3,7 @@ export type EventData = Record<string, unknown>;
 export type EventHeaders = {
   id: string;
   parentId?: string;
+  replyTo?: string[];
   type: string;
 };
 


### PR DESCRIPTION
Add a new `RequestReplyProcessor` class to handle request-reply patterns and introduce an optional `replyTo` header in events for routing replies.