### PR TITLE
fix: Refactoring of http services and types

### DIFF
--- a/src/http/composite-headers-provider.ts
+++ b/src/http/composite-headers-provider.ts
@@ -48,7 +48,11 @@ export class CompositeHeadersProvider<T extends Event = Event>
           });
         } else {
           Object.entries(providerHeaders).forEach(([name, value]) => {
-            headers.set(name, value);
+            if (Array.isArray(value)) {
+              value.forEach(v => headers.append(name, v));
+              return;
+            }
+            headers.set(name, value as string);
           });
         }
       }),

--- a/src/http/http-channel.ts
+++ b/src/http/http-channel.ts
@@ -9,8 +9,13 @@ export class HttpChannel<T extends Event = Event>
   async send(event: T): Promise<void> {
     this.emit('event:received', event);
 
-    await this.perform(event);
+    try {
+      await this.perform(event);
 
-    this.emit('event:delivered', event);
+      this.emit('event:delivered', event);
+    } catch (error) {
+      this.emit('event:error', event, error);
+      throw error;
+    }
   }
 }

--- a/src/http/http-processor.spec.ts
+++ b/src/http/http-processor.spec.ts
@@ -25,8 +25,6 @@ describe('HttpProcessor', function () {
   it('should return the response event', async function () {
     const processor = new HttpProcessor({
       url: 'http://test.local/',
-      deserializer: async (response: Response) =>
-        JSON.parse(await response.text()),
     });
     const event = await new EventBuilder().create();
     const response = await processor.process(event);

--- a/src/http/simple-http-event-service.spec.ts
+++ b/src/http/simple-http-event-service.spec.ts
@@ -53,6 +53,25 @@ describe('SimpleHttpEventService', function () {
     );
   });
 
+  it('should emit a response:error event if the response status is not 2xx', async function () {
+    const event = await EventBuilder.create();
+    nock('http://test.local').post('/').reply(500, 'Internal Server Error');
+    const listener = (e: Event, r: Response, err: Error) => {
+      expect(e).to.equal(event);
+      expect(r.ok).to.be.true;
+      expect(err.message).to.equal('Unexpected status code: 500');
+    };
+
+    const service = new SimpleHttpEventService({
+      url: 'http://test.local/',
+    });
+    service.on('response:error', listener);
+
+    expect(service.perform(event)).to.be.rejectedWith(
+      'Unexpected status code: 500',
+    );
+  });
+
   it('should take the url from the urlProvider', async function () {
     const scope = nock('http://test.local', {
       reqheaders: { 'Content-Type': 'application/json' },

--- a/src/http/simple-http-event-service.ts
+++ b/src/http/simple-http-event-service.ts
@@ -88,11 +88,14 @@ export class SimpleHttpEventService<T extends Event = Event>
     this.emit('request:created', event, request);
 
     const response = await fetch(request);
-    this.emit('response:received', event, response);
 
     if (response.status < 200 || response.status >= 300) {
-      throw new Error(`Unexpected status code: ${response.status}`);
+      const error = new Error(`Unexpected status code: ${response.status}`);
+      this.emit('response:error', event, response, error);
+      throw error;
     }
+
+    this.emit('response:received', event, response);
 
     return response;
   }

--- a/src/http/types/event-serializer.ts
+++ b/src/http/types/event-serializer.ts
@@ -8,11 +8,11 @@ type XMLHttpRequestBodyInit =
   | BufferSource
   | FormData
   | URLSearchParams;
-type BodyInit = ReadableStream<number> | XMLHttpRequestBodyInit;
+type BodyInit = XMLHttpRequestBodyInit | ReadableStream<number>;
 
 export type EventSerializerFn<T extends Event = Event> = (
   event: T,
-) => BodyInit | PromiseLike<BodyInit> | null | undefined;
+) => BodyInit | undefined | PromiseLike<BodyInit | undefined>;
 
 export interface EventSerializer<T extends Event = Event> {
   serialize: EventSerializerFn<T>;

--- a/src/http/types/headers-provider.ts
+++ b/src/http/types/headers-provider.ts
@@ -5,8 +5,7 @@ import {
   EventBasedProviderFn,
 } from '../../types/index.js';
 
-// Pretty certain I can import this from somewhere else. For now, I'll just copy it.
-type HeadersInit = [string, string][] | Record<string, string> | Headers;
+type HeadersInit = Headers | [string, string][] | Record<string, string>;
 
 export type HeadersProviderFn<T extends Event = Event> = EventBasedProviderFn<
   T,

--- a/src/http/types/index.ts
+++ b/src/http/types/index.ts
@@ -2,4 +2,5 @@ export * from './event-deserializer.js';
 export * from './event-serializer.js';
 export * from './headers-provider.js';
 export * from './http-event-service.js';
+export * from './response-event-extractor.js';
 export * from './url-provider.js';

--- a/src/http/types/response-event-extractor.ts
+++ b/src/http/types/response-event-extractor.ts
@@ -1,0 +1,14 @@
+import { Component } from '@sektek/utility-belt';
+
+import { Event } from '../../types/index.js';
+
+export type ResponseEventExtractorFn<T extends Event = Event> = (
+  response: Response,
+) => T | PromiseLike<T>;
+
+export interface ResponseEventExtractor<T extends Event = Event> {
+  extract: ResponseEventExtractorFn<T>;
+}
+
+export type ResponseEventExtractorComponent<T extends Event = Event> =
+  Component<ResponseEventExtractor<T>, 'extract'>;


### PR DESCRIPTION
Corrects some type information along with adding an event emitter for event:error to the SimpleHttpEventService when an exception is raised within the handler.