### PR TITLE
fix: resolve typing issues in event-serializer

### DIFF
--- a/src/http/types/event-serializer.ts
+++ b/src/http/types/event-serializer.ts
@@ -1,18 +1,25 @@
 import { Component } from '@sektek/utility-belt';
+
 import { Event } from '../../types/index.js';
 
-type BufferSource = ArrayBufferView | ArrayBuffer;
-type XMLHttpRequestBodyInit =
-  | string
+// Having some typing issues with BodyInit and fetch
+// So I'm commenting out the types that are causing conflicts
+type BodyInit =
+  | ArrayBuffer
+  // | AsyncIterable<Uint8Array>
   | Blob
-  | BufferSource
   | FormData
-  | URLSearchParams;
-type BodyInit = XMLHttpRequestBodyInit | ReadableStream<number>;
+  // | Iterable<Uint8Array>
+  // | ArrayBufferView
+  | URLSearchParams
+  | null
+  | string;
+
+type EventSerializerReturnType = undefined | BodyInit;
 
 export type EventSerializerFn<T extends Event = Event> = (
   event: T,
-) => BodyInit | undefined | PromiseLike<BodyInit | undefined>;
+) => EventSerializerReturnType | PromiseLike<EventSerializerReturnType>;
 
 export interface EventSerializer<T extends Event = Event> {
   serialize: EventSerializerFn<T>;


### PR DESCRIPTION
Had some issues with a few types that were part of the BodyInit type. Commenting them out for the time being.