### PR TITLE
chore: ignore .claude/settings.local.json; add bumpStrict to release-it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,5 @@ tmp/
 third-party/
 
 dist/
+
+.claude/settings.local.json

--- a/.release-it.json
+++ b/.release-it.json
@@ -3,7 +3,8 @@
     "@release-it/conventional-changelog": {
       "preset": {
         "name": "conventionalcommits",
-        "preMajor": true
+        "preMajor": true,
+        "bumpStrict": true
       },
       "infile": "CHANGELOG.md"
     }
@@ -12,7 +13,9 @@
     "commitMessage": "chore: release v${version} [skip ci]",
     "tagName": "v${version}",
     "push": true,
-    "pushArgs": ["--follow-tags"]
+    "pushArgs": [
+      "--follow-tags"
+    ]
   },
   "github": {
     "release": true,


### PR DESCRIPTION
## Summary

- Adds `.claude/settings.local.json` to `.gitignore` to prevent local Claude Code settings from being committed.
- Adds `bumpStrict: true` to the `release-it` conventional changelog preset.