### PR TITLE
feat: replace Node events with eventemitter3 for browser compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@sektek/utility-belt": "^0.3.0",
+        "eventemitter3": "^5.0.4",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1",
         "uuid": "^13.0.0"
@@ -5022,6 +5023,12 @@
       "funding": {
         "url": "https://github.com/bgub/eta?sponsor=1"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@sektek/utility-belt": "^0.3.0",
+        "@sektek/utility-belt": "^0.3.1",
         "eventemitter3": "^5.0.4",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1",
@@ -1664,11 +1664,12 @@
       }
     },
     "node_modules/@sektek/utility-belt": {
-      "version": "0.3.0",
-      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.3.0/a1e4154761248ec60ffb17bcdb23abfbf31e1317",
-      "integrity": "sha512-04lsqSY0oBoZTHE7ComXdV0T3QrsiIJUIY49XWP/A8n+RQjPpGZMPYxH23ffIVTcI5lUg59FFj+TU1Sl3CBUmw==",
+      "version": "0.3.1",
+      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.3.1/db220cecb8d881d961d5da7367203da02709d201",
+      "integrity": "sha512-KVq8o8N7Rd1Ga4/5fDBM8gLjKRY/oi28gB8z95FCirm9HbR8/EOwtNq6oJc09g4YUpFEP9XBCMjH5L4G0zp06g==",
       "license": "MIT",
       "dependencies": {
+        "eventemitter3": "^5.0.4",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1",
         "undici-types": "^7.8.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release": "release-it --ci"
   },
   "dependencies": {
-    "@sektek/utility-belt": "^0.3.0",
+    "@sektek/utility-belt": "^0.3.1",
     "eventemitter3": "^5.0.4",
     "lodash": "^4.17.23",
     "tslib": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@sektek/utility-belt": "^0.3.0",
+    "eventemitter3": "^5.0.4",
     "lodash": "^4.17.23",
     "tslib": "^2.8.1",
     "uuid": "^13.0.0"

--- a/src/abstract-event-service.ts
+++ b/src/abstract-event-service.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'eventemitter3';
 
 import { LoggerProvider, NullLoggerProvider } from '@sektek/utility-belt';
 

--- a/src/channels/null-channel.ts
+++ b/src/channels/null-channel.ts
@@ -1,5 +1,5 @@
 import { Event, EventChannel, EventService } from '../types/index.js';
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'eventemitter3';
 
 /**
  * An EventChannel class that does nothing but emit events.

--- a/src/handlers/null-handler.ts
+++ b/src/handlers/null-handler.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'eventemitter3';
 
 import { Event, EventHandler, EventService } from '../types/index.js';
 


### PR DESCRIPTION
## Summary

- Replaces `import EventEmitter from 'events'` in `AbstractEventService`, `NullChannel`, and `NullHandler` with `eventemitter3`, enabling synaptik to be used in browser environments
- Adds `eventemitter3@^5.0.4` as a production dependency
- No public API changes — all `on`, `emit`, and other EventEmitter methods remain identical
- Note: eventemitter3's default import is a namespace under Node16 module resolution; all three files use the named `{ EventEmitter }` import

## Test plan

- [x] All 175 existing tests pass
- [x] Build compiles cleanly
- [x] Lint passes (no-cache)

Closes [SEK-17](https://linear.app/sektek/issue/SEK-17)