### PR TITLE
feat: support sending errors to PromiseChannel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
-        "@sektek/utility-belt": "^0.3.2",
+        "@sektek/utility-belt": "^0.3.5",
         "eventemitter3": "^5.0.4",
         "lodash": "^4.17.23",
         "tslib": "^2.8.1",
@@ -1664,9 +1664,9 @@
       }
     },
     "node_modules/@sektek/utility-belt": {
-      "version": "0.3.2",
-      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.3.2/ed83bfb0b36e719a4473bbb35ceb683e13224fe7",
-      "integrity": "sha512-uJMdf+RdO/7nJQIPA9c801q5BSADumYX4nmKug20Hg+dnso8hBIMzL50sCxkHe4XxgR1mdFxJ5brLyGRqrleOQ==",
+      "version": "0.3.5",
+      "resolved": "https://npm.pkg.github.com/download/@sektek/utility-belt/0.3.5/52723f3f094a05b3b9ac91ead7e30edaf13dc83a",
+      "integrity": "sha512-SffBDAd+KEWMguOHbUTh1Amw5IHnFPVdYHHspkFza/ZW5UCzIJFspLIttuZCO/RxRCqZCbqlNa70Y7eW8FwIwQ==",
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release": "release-it --ci"
   },
   "dependencies": {
-    "@sektek/utility-belt": "^0.3.2",
+    "@sektek/utility-belt": "^0.3.5",
     "eventemitter3": "^5.0.4",
     "lodash": "^4.17.23",
     "tslib": "^2.8.1",

--- a/src/channels/promise-channel.spec.ts
+++ b/src/channels/promise-channel.spec.ts
@@ -90,4 +90,70 @@ describe('PromiseChannel', function () {
 
     expect(channel.state).to.equal('rejected');
   });
+
+  describe('sending an error', function () {
+    it('should reject the promise when sending an error', async function () {
+      const channel = new PromiseChannel<Event>();
+      const error = new Error('boom');
+      const promise = channel.get();
+      channel.send(error);
+
+      await expect(promise).to.be.rejectedWith('boom');
+    });
+
+    it('should have a state of rejected after sending an error', async function () {
+      const channel = new PromiseChannel<Event>();
+      const error = new Error('boom');
+      const promise = channel.get();
+      await expect(channel.send(error)).to.not.be.rejected;
+      await expect(promise).to.be.rejectedWith('boom');
+
+      expect(channel.state).to.equal('rejected');
+    });
+
+    it('should emit an event:error event when sending an error', async function () {
+      const listener = fake();
+      const channel = new PromiseChannel<Event>();
+      const error = new Error('boom');
+      const promise = channel.get();
+      channel.on('event:error', listener);
+      await channel.send(error);
+      await expect(promise).to.be.rejectedWith('boom');
+
+      expect(listener.calledWith(error)).to.be.true;
+    });
+
+    it('should not emit an event:delivered event when sending an error', async function () {
+      const listener = fake();
+      const channel = new PromiseChannel<Event>();
+      const error = new Error('boom');
+      const promise = channel.get();
+      channel.on('event:delivered', listener);
+      await channel.send(error);
+      await expect(promise).to.be.rejectedWith('boom');
+
+      expect(listener.called).to.be.false;
+    });
+
+    it('should emit an event:error event when sending an error after the promise has been resolved', async function () {
+      const listener = fake();
+      const channel = new PromiseChannel<Event>();
+      const event = await new EventBuilder().create();
+      const error = new Error('boom');
+      await channel.send(event);
+      channel.on('event:error', listener);
+      await expect(channel.send(error)).to.be.rejectedWith(
+        'Promise already resolved',
+      );
+
+      expect(
+        listener.calledWith(
+          match
+            .instanceOf(Error)
+            .and(match.has('message', 'Promise already resolved')),
+          error,
+        ),
+      ).to.be.true;
+    });
+  });
 });

--- a/src/channels/promise-channel.spec.ts
+++ b/src/channels/promise-channel.spec.ts
@@ -120,7 +120,7 @@ describe('PromiseChannel', function () {
       await channel.send(error);
       await expect(promise).to.be.rejectedWith('boom');
 
-      expect(listener.calledWith(error)).to.be.true;
+      expect(listener.calledOnceWith(error)).to.be.true;
     });
 
     it('should not emit an event:delivered event when sending an error', async function () {
@@ -147,7 +147,7 @@ describe('PromiseChannel', function () {
       );
 
       expect(
-        listener.calledWith(
+        listener.calledOnceWith(
           match
             .instanceOf(Error)
             .and(match.has('message', 'Promise already resolved')),

--- a/src/channels/promise-channel.ts
+++ b/src/channels/promise-channel.ts
@@ -83,7 +83,9 @@ export class PromiseChannel<T extends Event = Event>
    */
   async send(event: T | Error) {
     const eventIsError = isError(event);
-    this.emit(eventIsError ? EVENT_ERROR : EVENT_RECEIVED, event);
+    if (!eventIsError) {
+      this.emit(EVENT_RECEIVED, event);
+    }
 
     if (this.#state !== 'pending') {
       const error = new Error('Promise already resolved');

--- a/src/channels/promise-channel.ts
+++ b/src/channels/promise-channel.ts
@@ -1,4 +1,4 @@
-import { EventEmittingService } from '@sektek/utility-belt';
+import { EventEmittingService, isError } from '@sektek/utility-belt';
 
 import {
   AbstractEventComponent,
@@ -51,7 +51,7 @@ export class PromiseChannel<T extends Event = Event>
       };
       this.#reject = (reason?: unknown) => {
         this.#state = 'rejected';
-        if (reason instanceof Error) {
+        if (isError(reason)) {
           this.emit(EVENT_ERROR, reason);
         } else {
           this.emit(EVENT_ERROR, new Error('Promise rejected'));
@@ -75,13 +75,15 @@ export class PromiseChannel<T extends Event = Event>
 
   /**
    * Delivers an event to the promise created with the channel.
-   * The promise will resolve with the event.
+   * The promise will resolve with the event, or reject if an `Error` is
+   * sent instead.
    *
-   * @param event - The event to send.
+   * @param event - The event, or an `Error` to reject the promise with.
    * @throws {Error} If the channel has not been initialized.
    */
-  async send(event: T) {
-    this.emit(EVENT_RECEIVED, event);
+  async send(event: T | Error) {
+    const eventIsError = isError(event);
+    this.emit(eventIsError ? EVENT_ERROR : EVENT_RECEIVED, event);
 
     if (this.#state !== 'pending') {
       const error = new Error('Promise already resolved');
@@ -93,6 +95,11 @@ export class PromiseChannel<T extends Event = Event>
       const error = new Error('Promise not initialized');
       this.emit(EVENT_ERROR, error, event);
       throw error;
+    }
+
+    if (eventIsError) {
+      this.#reject?.(event);
+      return;
     }
 
     this.#resolve(event);


### PR DESCRIPTION
## Summary
- `PromiseChannel.send()` now accepts an `Error` in addition to an event; sending an `Error` rejects the channel's promise (via the existing `#reject` path) instead of resolving it, and emits `event:error` instead of `event:received`/`event:delivered`.
- Bump `@sektek/utility-belt` to `^0.3.5` to pick up the new `isError` predicate.
- Replace the inline `instanceof Error` checks with utility-belt's `isError`.
- Add tests covering: rejecting the promise, ending in a `rejected` state, `event:error` emission, no `event:delivered` emission, and sending an error after the promise has already resolved.

## Testing
- `npm run test:min`
- `npm run lint -- --no-cache`
- `npm run build`